### PR TITLE
Add Hugging Face integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/depth_anything/dpt.py
+++ b/depth_anything/dpt.py
@@ -205,7 +205,7 @@ if __name__ == '__main__':
     model.load_state_dict(state_dict)
 
     # save locally
-    # model.save_pretrained("depth_anything_dinov2_vits14")
+    # model.save_pretrained("depth_anything_dinov2_vits14", config=config)
 
     # upload to huggingface hub
     # model.push_to_hub("nielsr/depth_anything_dinov2_vits14", config=config)


### PR DESCRIPTION
Hi,

Thanks for this nice work. I wrote a quick PoC to showcase that you can easily have integration so that you can automatically load the various Depth Anything models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherit these methods.

Usage is as follows:

```
import numpy as np
from PIL import Image
import torch

from depth_anything.dpt import DepthAnything
from depth_anything.util.transform import Resize, NormalizeImage, PrepareForNet
from torchvision.transforms import Compose

model = DepthAnything.from_pretrained("nielsr/depth_anything_dinov2_vits14")

transform = Compose([
        Resize(
            width=518,
            height=518,
            resize_target=False,
            keep_aspect_ratio=True,
            ensure_multiple_of=14,
            resize_method='lower_bound',
            image_interpolation_method=cv2.INTER_CUBIC,
        ),
        NormalizeImage(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
        PrepareForNet(),
    ])

img = Image.open(...)
image = transform({'image': np.array(image)})['image']
image = torch.from_numpy(image).unsqueeze(0)

depth = model(image)
```
The corresponding model is here for now: https://huggingface.co/nielsr/depth_anything_dinov2_vits14. We could move all checkpoints to separate repos on the [TikToken organization](https://huggingface.co/tiktok) if you're interested.

I saw that currently download numbers won't be tracked since all checkpoints are just part of a single repository.

Would you be interested in this integration?

Kind regards,

Niels