### PR TITLE
Bug Fix - Type error when evaluating metric depth on Kitti

### DIFF
--- a/metric_depth/zoedepth/models/base_models/depth_anything.py
+++ b/metric_depth/zoedepth/models/base_models/depth_anything.py
@@ -171,7 +171,7 @@ class Resize(object):
 
     def __call__(self, x):
         width, height = self.get_size(*x.shape[-2:][::-1])
-        return nn.functional.interpolate(x, (height, width), mode='bilinear', align_corners=True)
+        return nn.functional.interpolate(x, (int(height), int(width)), mode='bilinear', align_corners=True)
 
 class PrepForMidas(object):
     def __init__(self, resize_mode="minimal", keep_aspect_ratio=True, img_size=384, do_resize=True):


### PR DESCRIPTION
This pull request addresses the type error encountered when evaluating the fine-tuned Depth-Anything model on the Kitti dataset , a similar issue with ZoeDepth was reported here - [#2113](https://github.com/Mikubill/sd-webui-controlnet/issues/2113).

The error had two proposed solutions:
1. Downgrade the torch version.
2. Manually adjust the height and width in the model code.

I opted for the second solution, modifying the height and width manually. This decision was made to avoid potential compatibility issues with future versions of xFormers, which may require a more recent version of torch. Downgrading torch, while a viable short-term fix, could lead to more significant maintenance challenges down the line.