### PR TITLE
minor issue on depth_to_pointcloud.py

### DIFF
--- a/metric_depth/depth_to_pointcloud.py
+++ b/metric_depth/depth_to_pointcloud.py
@@ -37,11 +37,7 @@ def process_images(model):
             original_width, original_height = color_image.size
             image_tensor = transforms.ToTensor()(color_image).unsqueeze(0).to('cuda' if torch.cuda.is_available() else 'cpu')
 
-            pred = model(image_tensor, dataset=DATASET)
-            if isinstance(pred, dict):
-                pred = pred.get('metric_depth', pred.get('out'))
-            elif isinstance(pred, (list, tuple)):
-                pred = pred[-1]
+            pred = model.infer(image_tensor)
             pred = pred.squeeze().detach().cpu().numpy()
 
             # Resize color image and depth to final size


### PR DESCRIPTION
When I try to get the metric depth with depth_to_pointcloud.py I have found a minor issue.

**Problem**
Metric depth estimation is to fine-tune the pipeline of ZoeDepth. In ZoeDepth, the input image should be augmented by flip and repetitive padding transforms before getting results. Because depth_to_pointcloud.py skip the mentioned step, noisy boundary of the depth map might be generated.

**What I did**
I simply revised an inference line to use [infer()](https://github.com/seung0h/Depth-Anything/blob/main/metric_depth/zoedepth/models/depth_model.py#L115) function instead of the forward process and it automatically resolves the augmentation problem. 

**After modification**
The results are attached for validating code modification.

Before
<img src="https://github.com/LiheYoung/Depth-Anything/assets/166125470/e092c003-6448-41fd-bd21-03f23f3b1adb" height="350">
After
<img src="https://github.com/LiheYoung/Depth-Anything/assets/166125470/14f0f4da-f80f-487d-8d62-28f147ada22b" height="350">
- infer() has the same shape as the training input (480, 640)